### PR TITLE
Fix GoReleaser v2 config and track CLAUDE.md

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Unshallow
-        run: git fetch --prune --unshallow
+        with:
+          fetch-depth: 0
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -34,9 +34,10 @@ jobs:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
-          version: latest
+          distribution: goreleaser
+          version: '~> v2'
           args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 before:
   hooks:
     - go mod tidy
@@ -24,7 +26,7 @@ builds:
       goarch: '386'
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
-- format: zip
+- formats: ['zip']
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
@@ -40,4 +42,4 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 changelog:
-  skip: true
+  disable: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A Terraform provider (`github.com/pilat/terraform-provider-sql`) exposing a single `sql` resource that runs `up` SQL on create and `down` SQL on destroy. PostgreSQL only — the driver is hardcoded to `postgres` (`lib/pq`).
+
+## Commands
+
+- Test: `go test ./...` (the only CI command; there is no Makefile)
+- Release: handled by goreleaser on a `v*` git tag — do not run manually
+
+## Stack
+
+- Built on `terraform-plugin-sdk/v2` (v2.28.0), **not** the newer terraform-plugin-framework. Write schema/CRUD code in the SDK v2 style (`*schema.Resource`, `*schema.ResourceData`, `diag.Diagnostics`) — framework patterns do not apply here.
+
+## Intentional design (do not "fix" these)
+
+These look like bugs but are deliberate (see commits "Do not allow to change up attribute", "Ignore update handler"):
+
+- `up` is immutable after create — `CustomizeDiff` rejects changes to it.
+- `Update` performs no SQL; it only warns when `database`/`down` change. State updates, DB is untouched.
+- `Read` is a no-op — the provider does not reconcile against actual DB state.
+- Resource ID is the first 8 chars of `sha256(up)`.
+- Multiline SQL is split on `;\n` / `;\r\n`, so statements must end with a semicolon followed by a newline.
+
+## Notes
+
+- `tests/` holds manual integration tests (docker-compose Postgres + a `.tf` config). Work in progress — not wired into CI; treat as scratch.


### PR DESCRIPTION
## Why

PR #3 moved the release workflow onto `goreleaser-action@v6`, which runs GoReleaser **v2** — but `.goreleaser.yml` was still v1 syntax, so the next `v*` tag would fail the release. It was actually latently broken even before #3: `version: latest` already pulled v2, and the old `--rm-dist` flag is gone in v2. The last green release (`v0.0.8`) was cut on GoReleaser v1 back in 2023.

This needs to land before tagging the next version, otherwise the release run dies on config validation.

## What

- **`.goreleaser.yml` → v2.** Added the `version: 2` header, `archives.format` → `formats`, and `changelog.skip` → `changelog.disable`. Validated locally with `goreleaser check`. GPG checksum signing is kept — the Terraform registry requires signed releases.
- **`release.yml` aligned with the fleetbox releaser.** `goreleaser-action@v7` with `distribution: goreleaser` + `version: '~> v2'`, and `fetch-depth: 0` on checkout instead of the separate unshallow step.
- **Track `CLAUDE.md`.** It was sitting untracked in the repo; it's project guidance and belongs in version control.
